### PR TITLE
Assert float input type for Scalar class

### DIFF
--- a/minitorch/scalar.py
+++ b/minitorch/scalar.py
@@ -45,6 +45,7 @@ class Scalar(Variable):
 
     def __init__(self, v, back=History(), name=None):
         super().__init__(back, name=name)
+        assert isinstance(v, float), "Expected input value typ %s got %s" % (float, type(v))
         self.data = v
 
     def __repr__(self):

--- a/minitorch/scalar.py
+++ b/minitorch/scalar.py
@@ -45,7 +45,7 @@ class Scalar(Variable):
 
     def __init__(self, v, back=History(), name=None):
         super().__init__(back, name=name)
-        assert isinstance(v, float), "Expected input value typ %s got %s" % (float, type(v))
+        assert isinstance(v, float), f"Expected input value type float got {type(v)}"
         self.data = v
 
     def __repr__(self):

--- a/minitorch/scalar.py
+++ b/minitorch/scalar.py
@@ -45,8 +45,7 @@ class Scalar(Variable):
 
     def __init__(self, v, back=History(), name=None):
         super().__init__(back, name=name)
-        assert isinstance(v, float), f"Expected input value type float got {type(v)}"
-        self.data = v
+        self.data = float(v)
 
     def __repr__(self):
         return "Scalar(%f)" % self.data


### PR DESCRIPTION
This PR resolves the below type of downstream errors due to type mismatch. 
![Screen Shot 2020-09-18 at 3 31 02 PM](https://user-images.githubusercontent.com/23729788/93652735-23ff1200-f9e4-11ea-9621-9baf32144448.png)

New behavior: 
![Screen Shot 2020-09-18 at 7 23 31 PM](https://user-images.githubusercontent.com/23729788/93652857-86f0a900-f9e4-11ea-9a52-aacf507372ec.png)


Please refer to the [Piazza question](https://piazza.com/class/kbtd4b1lt1c6so?cid=82_f9) to read the issue thread. 