### PR TITLE
allow using latest mypy to avoid error prompt of numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorama==0.4.3
 hypothesis == 6.54
-mypy == 0.971
+mypy
 numba == 0.56
 numpy == 1.22
 pre-commit == 2.20.0


### PR DESCRIPTION
If we still use mypy==0.971, then mypy will report the following error, which is based on this bug:https://github.com/python/mypy/issues/13627
```
xxx/lib/python3.10/site-packages/numpy/__init__.pyi:636:48: error: Positional-only parameters are only supported in Python 3.8 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```